### PR TITLE
SEC-4543: Support Testing mode & Accept Multiple Google Groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ You can use the AWS Serverless Application Model (SAM) to deploy this to your ac
 > Please, install the [AWS SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) and [GoReleaser](https://goreleaser.com/install/).
 
 Specify an Amazon S3 Bucket for the upload with `export S3_BUCKET=<YOUR_BUCKET>`.
+Specify an Amazon S3 Prefix for all deployments with `export S3_PREFIX=<YOUR_DEPLOYMENT_PREFIX>`
 
 Execute `make package` in the console. Which will package and upload the function to the bucket. You can then use the `packaged.yaml` to configure and deploy the stack in [AWS CloudFormation Console](https://console.aws.amazon.com/cloudformation).
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -162,6 +162,7 @@ func configLambda() {
 func addFlags(cmd *cobra.Command, cfg *config.Config) {
 	rootCmd.PersistentFlags().StringVarP(&cfg.GoogleCredentials, "google-admin", "a", config.DefaultGoogleCredentials, "path to find credentials file for Google Workspace")
 	rootCmd.PersistentFlags().BoolVarP(&cfg.Debug, "debug", "d", config.DefaultDebug, "enable verbose / debug logging")
+	rootCmd.PersistentFlags().BoolVarP(&cfg.Testing, "testing", "i", config.DefaultTesting, "enable testing mode")
 	rootCmd.PersistentFlags().StringVarP(&cfg.LogFormat, "log-format", "", config.DefaultLogFormat, "log format")
 	rootCmd.PersistentFlags().StringVarP(&cfg.LogLevel, "log-level", "", config.DefaultLogLevel, "log level")
 	rootCmd.Flags().StringVarP(&cfg.SCIMAccessToken, "access-token", "t", "", "AWS SSO SCIM API Access Token")
@@ -171,8 +172,8 @@ func addFlags(cmd *cobra.Command, cfg *config.Config) {
 	rootCmd.Flags().StringSliceVar(&cfg.IgnoreUsers, "ignore-users", []string{}, "ignores these Google Workspace users")
 	rootCmd.Flags().StringSliceVar(&cfg.IgnoreGroups, "ignore-groups", []string{}, "ignores these Google Workspace groups")
 	rootCmd.Flags().StringSliceVar(&cfg.IncludeGroups, "include-groups", []string{}, "include only these Google Workspace groups, NOTE: only works when --sync-method 'users_groups'")
-	rootCmd.Flags().StringVarP(&cfg.UserMatch, "user-match", "m", "", "Google Workspace Users filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users")
-	rootCmd.Flags().StringVarP(&cfg.GroupMatch, "group-match", "g", "", "Google Workspace Groups filter query parameter, example: 'name:Admin* email:aws-*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups")
+	rootCmd.Flags().StringSliceVarP(&cfg.UserMatch, "user-match", "m", []string{}, "Google Workspace Users filter query parameter, example: 'name:John* email:admin*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-users")
+	rootCmd.Flags().StringSliceVarP(&cfg.GroupMatch, "group-match", "g", []string{}, "Google Workspace Groups filter query parameter, example: 'name:Admin* email:aws-*', see: https://developers.google.com/admin-sdk/directory/v1/guides/search-groups")
 	rootCmd.Flags().StringVarP(&cfg.SyncMethod, "sync-method", "s", config.DefaultSyncMethod, "Sync method to use (users_groups|groups)")
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,8 @@ package config
 type Config struct {
 	// Verbose toggles the verbosity
 	Debug bool
+	// Testing mode that does not commit changes
+	Testing bool
 	// LogLevel is the level with with to log for this config
 	LogLevel string `mapstructure:"log_level"`
 	// LogFormat is the format that is used for logging
@@ -14,9 +16,9 @@ type Config struct {
 	// GoogleAdmin ...
 	GoogleAdmin string `mapstructure:"google_admin"`
 	// UserMatch ...
-	UserMatch string `mapstructure:"user_match"`
+	UserMatch []string `mapstructure:"user_match"`
 	// GroupFilter ...
-	GroupMatch string `mapstructure:"group_match"`
+	GroupMatch []string `mapstructure:"group_match"`
 	// SCIMEndpoint ....
 	SCIMEndpoint string `mapstructure:"scim_endpoint"`
 	// SCIMAccessToken ...
@@ -40,6 +42,8 @@ const (
 	DefaultLogFormat = "text"
 	// DefaultDebug is the default debug status.
 	DefaultDebug = false
+	// DefaultTesting is the default testing status.
+	DefaultTesting = false
 	// DefaultGoogleCredentials is the default credentials path
 	DefaultGoogleCredentials = "credentials.json"
 	// DefaultSyncMethod is the default sync method to use.


### PR DESCRIPTION
See the Panopedia page on [AWS SSO Sync](https://panoramaed.atlassian.net/wiki/spaces/ENG/pages/2833842186/AWS+SSO+Sync) on the purpose of this script and how to run it.

This PR adds two pieces of functionality:
* A testing mode by adding a `--testing` flag when running the script.  This avoids any calls to Create/Update/Delete actions in AWS.
* The ability the pass in multiple Google Groups or Users to include in the sync simultaneously. (`-g "name:'<GOOGLE_GROUP_1>',name:'<GOOGLE_GROUP_2>'`

Tested by running the script locally.  Note that I also had to have `credentials.json` downloaded with the Google IAM credentials. First ran with a testing flag and confirmed this made no changes.
```
SSOSYNC_SCIM_ENDPOINT=<SSOSYNC_SCIM_ENDPOINT> SSOSYNC_SCIM_ACCESS_TOKEN=<SSOSYNC_SCIM_ACCESS_TOKEN> ./ssosync -u lmercado@panoramaed.com -g "name=Engineering,name='Engineering Accounts',name='Integration Tools Squad',name='Implementation Leads',name='Infrastructure Squad',name='Data Science Infrastructure Squad',name='CX Implementation Interns',name=behavior-zone,name=cii-zone,name='Blue Zone',name='Security Squad',name='AWS Test Group'" -d --testing
```

Then without a testing flag and confirming that all expected users from the passed in Google Groups appeared in IAM Identity Center.